### PR TITLE
Upgrade to Apache Parent 31

### DIFF
--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>29</version>
+    <version>31</version>
   </parent>
 
   <groupId>org.apache.velocity</groupId>
@@ -37,6 +37,14 @@
   <description>Master POM for Velocity</description>
   <url>https://velocity.apache.org/</url>
   <inceptionYear>2000</inceptionYear>
+
+  <properties>
+    <minimalMavenBuildVersion>3.2.5</minimalMavenBuildVersion>
+    <javaVersion>8</javaVersion>
+    <maven.compiler.source>${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <project.build.outputTimestamp>2024-01-17T00:00:00Z</project.build.outputTimestamp>
+  </properties>
 
   <developers>
     <developer>
@@ -206,7 +214,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
           </configuration>
@@ -214,7 +221,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.1.0</version>
           <executions>
             <execution>
               <id>enforce-bytecode-version</id>
@@ -235,7 +241,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
-              <version>1.6.1</version>
+              <version>1.7.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Explicitly require Maven 3.2.5+ to build and Java 8 as runtime